### PR TITLE
[Fix/Refactor] 대기열 필터 및 JWT 인증 흐름 개선

### DIFF
--- a/src/main/java/com/tickatch/gateway_server/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tickatch/gateway_server/security/JwtAuthenticationFilter.java
@@ -20,6 +20,11 @@ public class JwtAuthenticationFilter implements WebFilter {
   @Override
   public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
 
+    // 응답이 이미 커밋되었다면 스킵
+    if (exchange.getResponse().isCommitted()) {
+      return Mono.empty();
+    }
+
     // 이미 실행되었다면 스킵
     Boolean alreadyApplied = exchange.getAttribute(JWT_FILTER_APPLIED);
     if (Boolean.TRUE.equals(alreadyApplied)) {
@@ -31,6 +36,7 @@ public class JwtAuthenticationFilter implements WebFilter {
 
     // 서버 내부에서 사용하는 헤더 값들은 제거
     ServerWebExchange sanitizedExchange = getSanitizedExchange(exchange);
+//    ServerWebExchange sanitizedExchange = exchange;
 
     return ReactiveSecurityContextHolder.getContext()
         .filter(context -> context.getAuthentication() != null)

--- a/src/main/java/com/tickatch/gateway_server/waiting_queue/infrastructure/filter/QueueFilter.java
+++ b/src/main/java/com/tickatch/gateway_server/waiting_queue/infrastructure/filter/QueueFilter.java
@@ -27,6 +27,11 @@ public class QueueFilter implements WebFilter, Ordered {
 
   @Override
   public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+    // 응답이 이미 커밋되었다면 스킵
+    if (exchange.getResponse().isCommitted()) {
+      return Mono.empty();
+    }
+
     String path = exchange.getRequest().getPath().value();
     HttpMethod method = exchange.getRequest().getMethod();
     String userId = exchange.getRequest().getHeaders().getFirst("X-User-Id");
@@ -37,28 +42,10 @@ public class QueueFilter implements WebFilter, Ordered {
       return chain.filter(exchange);
     }
 
-    // 응답이 이미 커밋되었다면 스킵
-    if (exchange.getResponse().isCommitted()) {
-      return chain.filter(exchange);
-    }
-
-    // 큐 필터를 통과했다는 기록을 속성에 남김
+    // 대기열 필터를 통과했다는 기록을 속성에 남김
     exchange.getAttributes().put(QUEUE_FILTER_APPLIED, true);
 
-
-    // 1. 화이트리스트 체크
-    if (isWhitelistPath(path, method)) {
-      return chain.filter(exchange);
-    }
-
-    // 2. 로그인 체크
-    if (!StringUtils.hasText(userId)) {
-      return responseHelper.writeError(
-          exchange, HttpStatus.UNAUTHORIZED, "USER_ID_REQUIRED", "로그인이 필요합니다."
-      );
-    }
-
-    // 3. 입장 가능한지 체크 (예매 관련 API만 대기열 적용)
+    // 1. 입장 가능한지 체크 (예매 관련 API만 대기열 적용)
     // 입장 가능: 입장 허용 타임스탬프 갱신 + 요청 통과
     // 입장 불가: 대기열 상태 반환
     if (isReservationPath(path, method)){
@@ -68,11 +55,12 @@ public class QueueFilter implements WebFilter, Ordered {
               return rejectWithQueueInfo(exchange, userId);
             }
 
-            return queueService.refreshAllowedInTimeStamp(userId).then(chain.filter(exchange));
+            return queueService.refreshAllowedInTimeStamp(userId)
+                .then(Mono.defer(() -> chain.filter(exchange)));
           });
     }
 
-    // 4. 그 외 API는 통과
+    // 2. 그 외 API는 통과
     return chain.filter(exchange);
   }
 
@@ -86,32 +74,6 @@ public class QueueFilter implements WebFilter, Ordered {
         .onErrorResume(QueueException.class, e -> responseHelper.writeError(
             exchange, HttpStatus.FORBIDDEN, "NOT_IN_QUEUE", "대기열에 등록되지 않은 사용자입니다."
         ));
-  }
-
-  private boolean isWhitelistPath(String path, HttpMethod method) {
-    switch (path) {
-      // Auth 기본 API
-      case "/api/v1/auth/login":
-      case "/api/v1/auth/register":
-      case "/api/v1/auth/refresh":
-      case "/api/v1/auth/check-email":
-      case "/api/v1/auth/me":
-        return true;
-
-      default:
-        // OAuth
-        if (method == HttpMethod.GET &&
-            path.matches("^/api/v1/auth/oauth/[^/]+$")) {
-          return true;
-        }
-
-        if (method == HttpMethod.GET &&
-            path.matches("^/api/v1/auth/oauth/[^/]+/callback$")) {
-          return true;
-        }
-
-        return false;
-    }
   }
 
   private boolean isReservationPath(String path, HttpMethod method) {

--- a/src/main/java/com/tickatch/gateway_server/waiting_queue/infrastructure/security/AuthenticationEntryPoint.java
+++ b/src/main/java/com/tickatch/gateway_server/waiting_queue/infrastructure/security/AuthenticationEntryPoint.java
@@ -1,0 +1,24 @@
+package com.tickatch.gateway_server.waiting_queue.infrastructure.security;
+
+import com.tickatch.gateway_server.global.api.MonoResponseHelper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.server.ServerAuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticationEntryPoint implements ServerAuthenticationEntryPoint {
+
+  private final MonoResponseHelper responseHelper;
+
+  @Override
+  public Mono<Void> commence(ServerWebExchange exchange, AuthenticationException ex) {
+    return responseHelper.writeError(
+        exchange, HttpStatus.UNAUTHORIZED, "USER_ID_REQUIRED", "로그인이 필요합니다."
+    );
+  }
+}

--- a/src/main/java/com/tickatch/gateway_server/waiting_queue/presentation/webapi/QueueApi.java
+++ b/src/main/java/com/tickatch/gateway_server/waiting_queue/presentation/webapi/QueueApi.java
@@ -10,7 +10,6 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;

--- a/src/main/java/com/tickatch/gateway_server/waiting_queue/presentation/webapi/QueueApi.java
+++ b/src/main/java/com/tickatch/gateway_server/waiting_queue/presentation/webapi/QueueApi.java
@@ -5,6 +5,8 @@ import com.tickatch.gateway_server.waiting_queue.application.WaitingQueueService
 import com.tickatch.gateway_server.waiting_queue.application.dto.QueueStatusResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,13 +23,17 @@ public class QueueApi {
   private final WaitingQueueService queueService;
 
   @PostMapping("/lineup")
-  public Mono<ApiResponse<Void>> lineUp(@RequestHeader("X-User-Id") String userId) {
+  public Mono<ApiResponse<Void>> lineUp(@AuthenticationPrincipal Jwt jwt) {
+    String userId = jwt.getSubject();
+
     return queueService.lineUp(userId)
         .map(msg -> ApiResponse.success(null, msg));
   }
 
   @GetMapping("/status")
-  public Mono<ApiResponse<QueueStatusResponse>> status(@RequestHeader("X-User-Id") String userId) {
+  public Mono<ApiResponse<QueueStatusResponse>> status(@AuthenticationPrincipal Jwt jwt) {
+    String userId = jwt.getSubject();
+
     return queueService.canEnter(userId)
         .flatMap(canEnter -> {
           if (canEnter) {
@@ -40,7 +46,9 @@ public class QueueApi {
   }
 
   @DeleteMapping("/allowed-in-token")
-  public Mono<ApiResponse<Void>> removeAllowedInToken(@RequestHeader("X-User-Id") String userId) {
+  public Mono<ApiResponse<Void>> removeAllowedInToken(@AuthenticationPrincipal Jwt jwt) {
+    String userId = jwt.getSubject();
+
     return queueService.removeAllowedUserId(userId)
         .map(removed -> {
           if (removed) {
@@ -52,7 +60,9 @@ public class QueueApi {
   }
 
   @DeleteMapping("/waiting-token")
-  public Mono<ApiResponse<Void>> removeWaitingToken(@RequestHeader("X-User-Id") String userId) {
+  public Mono<ApiResponse<Void>> removeWaitingToken(@AuthenticationPrincipal Jwt jwt) {
+    String userId = jwt.getSubject();
+
     return queueService.removeWaitingUserId(userId)
         .map(removed -> {
           if (removed) {

--- a/src/main/java/com/tickatch/gateway_server/waiting_queue/presentation/webapi/QueueSseController.java
+++ b/src/main/java/com/tickatch/gateway_server/waiting_queue/presentation/webapi/QueueSseController.java
@@ -16,7 +16,6 @@ import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Flux;

--- a/src/main/java/com/tickatch/gateway_server/waiting_queue/presentation/webapi/QueueSseController.java
+++ b/src/main/java/com/tickatch/gateway_server/waiting_queue/presentation/webapi/QueueSseController.java
@@ -13,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,8 +33,9 @@ public class QueueSseController {
 
   @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
   public Flux<ServerSentEvent<Object>> streamQueueStatus(
-      @RequestHeader("X-User-Id") String userId) {
+      @AuthenticationPrincipal Jwt jwt) {
 
+    String userId = jwt.getSubject();
     log.info("SSE 연결 시작 - userId: {}", userId);
 
     return queueService.canEnter(userId)


### PR DESCRIPTION
# 1. 요약 (Summary)
- ServerAuthenticationEntryPoint를 도입하여 미인증 요청에 대한 응답을 일관되게 처리했습니다.
- WebFlux 필터의 비동기 특성으로 발생하던 중복 응답 커밋 문제를 해결했습니다.
- 인증/인가 책임을 SecurityWebFilterChain으로 이동시켜 필터 역할을 명확히 분리했습니다.
- 대기열 및 예매 API 접근 제어를 인증 사용자로 제한했습니다.

# 2. 작업 내용 (Details)
- #21
- ServerAuthenticationEntryPoint 구현체 추가
  - 미인증 사용자가 보호된 API 접근 시 "로그인이 필요합니다" 응답 반환
- JwtAuthenticationFilter 개선
  - 응답 커밋 여부 체크 로직 추가
  - 중복 응답 쓰기 방지
- 대기열 필터 리팩토링
  - 불필요한 화이트리스트 경로 체크 제거
  - 인증 판단 로직 제거 및 SecurityWebFilterChain으로 책임 위임
- Security 설정 개선
  - 대기열 API, 예매 API를 인증 필수 경로로 설정
- 컨트롤러 리팩토링
  - userId를 헤더가 아닌 `@AuthenticationPrincipal`에서 직접 추출하도록 수정



# 3. 변경 유형 (Change Type)
`FIX` / `REFACTOR` 

